### PR TITLE
Use `declare -g` instead of exporting options

### DIFF
--- a/argparse.sh
+++ b/argparse.sh
@@ -59,11 +59,11 @@ parse_args() {
 
         if [[ -n "${ARG_PROPERTIES[$key,help]}" ]]; then
             if [[ "${ARG_PROPERTIES[$key,type]}" == "bool" ]]; then
-                export "$key"="true"
+                declare -g "$key"="true"
                 shift # past the flag argument
             else
                 [[ -z "$2" || "$2" == --* ]] && display_error "Missing value for argument --$key"
-                export "$key"="$2"
+                declare -g "$key"="$2"
                 shift # past argument
                 shift # past value
             fi
@@ -81,7 +81,7 @@ parse_args() {
     # Set defaults for any unset arguments
     for arg in "${!ARG_PROPERTIES[@]}"; do
         arg_name="${arg%%,*}" # Extract argument name
-        [[ -z "${!arg_name}" ]] && export "$arg_name"="${ARG_PROPERTIES[$arg_name,default]}"
+        [[ -z "${!arg_name}" ]] && declare -g "$arg_name"="${ARG_PROPERTIES[$arg_name,default]}"
     done
 }
 

--- a/argparse3.sh
+++ b/argparse3.sh
@@ -70,7 +70,7 @@ define_arg() {
     if [[ "$arg_value" == "$_NULL_VALUE_" ]]; then
         arg_value=""
     fi
-    export "$arg_name"="$arg_value"
+    printf -v "$arg_name" '%s' "$arg_value"
 }
 
 # Function to parse command-line arguments
@@ -92,12 +92,12 @@ parse_args() {
                         echo "Missing value for argument --$key"
                         exit 1
                     else
-                        export "$key"="$2"
+                        printf -v "$key" '%s' "$2"
                         shift 2
                     fi
                 ;;
                 'bool')
-                    export "$key"='true'
+                    printf -v "$key" '%s' 'true'
                     shift
                 ;;
                 *)


### PR DESCRIPTION
Exporting the options exposes them to child processes, which may be surprising or harmful.